### PR TITLE
indention -> indentation

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -33,7 +33,7 @@ if has("persistent_undo")
   set undofile
 endif
 
-" Indention
+" Indentation
 set cindent
 set autoindent
 set smartindent
@@ -287,7 +287,7 @@ function! s:beauty()
 endfunction
 call <SID>beauty()
 
-" indention
+" indentation
 function! s:indent()
   if &softtabstop < 4 || &softtabstop == &tabstop
     highlight IndentGuidesOdd ctermbg=NONE


### PR DESCRIPTION
indention은 고어(archaic)라고 합니다. 위키백과의 Indent style 항목에서도 indentation으로만 쓰이고 있습니다. 그리고 같은 파일 안에서 indentation과 indention이 혼용되고 있으므로 하나로 통일하는 게 좋을 것 같습니다.
- http://www.merriam-webster.com/dictionary/indention
- https://en.wikipedia.org/wiki/Indent_style
