### PR TITLE
init.fish: >/dev/null 대신 -q

### DIFF
--- a/omf/init.fish
+++ b/omf/init.fish
@@ -2,9 +2,9 @@ set -x RUST_BACKTRACE=1
 if not set -q TMUX; set TERM xterm-256color; end
 
 # Aliases
-if type nvim >/dev/null; alias vim='nvim'; end # neovim
-if type tmux >/dev/null; alias irc='tmux attach -t irc'; end
-if type ag >/dev/null; if not hash pt 2>/dev/null; alias pt='ag'; end; end
+if type -q nvim; alias vim='nvim'; end # neovim
+if type -q tmux; alias irc='tmux attach -t irc'; end
+if type -q ag; if not type -q pt; alias pt='ag'; end; end
 
 # Golang
 set -x GOPATH ~/.go


### PR DESCRIPTION
type의 stdout을 /dev/null 로 보내는 방식은 stderr를 잡지 못하기 때문에 type 명령이 실패할 때 오류 메시지가 뜨게 됩니다. -q 옵션을 사용하면 짧은 명령으로 stdout과 stderr 모두 침묵시킬 수 있어서 좋습니다. type 내부적으로 /dev/null에다 대고 write 하는 syscall이 사라져서 성능상으로도 (미미하긴 하지만) 이득일 것 같군요.

중첩 if 안쪽에서 hash를 쓰고 있어 그것도 type으로 교체했습니다.
